### PR TITLE
build: use profile release-min for deploy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,9 @@ jobs:
       - name: check clippy
         run: cargo clippy --no-deps -- -D warnings
       - name: check build
-        run: cargo build --release
+        run: cargo build
       - name: check test
-        run: cargo test --release
+        run: cargo test
 
   changelog:
     name: Changelog Check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ serde_qs = "0.12.0"
 tokio = { version = "1.27.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 
-[profile.release]
+[profile.release-min]
+inherits = "release"
+# REF: https://github.com/johnthagen/min-sized-rust
+strip = true
 opt-level = 3
 lto = "fat"
 codegen-units = 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 ARG HTTPBIN_IMPL=httpbin-poem-openapi
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --profile release-min --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --bin $HTTPBIN_IMPL
+RUN cargo build --profile release-min --bin $HTTPBIN_IMPL
 
 FROM alpine:latest AS runtime
 ARG HTTPBIN_IMPL=httpbin-poem-openapi
-COPY --from=builder /app/target/release/$HTTPBIN_IMPL /usr/local/bin/httpbin
+COPY --from=builder /app/target/release-min/$HTTPBIN_IMPL /usr/local/bin/httpbin
 COPY httpbin.toml /etc/httpbin.toml
 EXPOSE 8080
 ENTRYPOINT httpbin --config /etc/httpbin.toml


### PR DESCRIPTION
Instead of overwriting the release profile, httpbin-rs now uses a new profile called `release-min` for the deploy target. The CI uses `dev` for build and test now.